### PR TITLE
Fixes bug where the actions on the get date and get time buttons were swapped around

### DIFF
--- a/TimeDashboard.Client/assets/src/repository/sources/time.datasource.ts
+++ b/TimeDashboard.Client/assets/src/repository/sources/time.datasource.ts
@@ -20,11 +20,11 @@ export class TimeManagementDataSource implements TimeDataSource {
     }
 
     async getTime(): Promise<DataSourceResponse<string>> {
-        return await tryExecuteAndNotify(this.#host, TimeResource.getDate())
+        return await tryExecuteAndNotify(this.#host, TimeResource.getTime())
     }
 
     async getDate(): Promise<DataSourceResponse<string>> {
-        return await tryExecuteAndNotify(this.#host, TimeResource.getTime())
+        return await tryExecuteAndNotify(this.#host, TimeResource.getDate())
     }
     
 }


### PR DESCRIPTION
Mapped the `getTime()` method to `TimeResource.getTime()` and same change in `getDate()`. 